### PR TITLE
Allow page change

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -17,14 +17,24 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The application page should change. */
+    private final boolean showPage;
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean showPage) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.showPage = showPage;
+    }
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
+        this(feedbackToUser, showHelp, exit, false);
     }
 
     /**
@@ -39,12 +49,27 @@ public class CommandResult {
         return feedbackToUser;
     }
 
+    /**
+     * Gets feedback string for system uses.
+     * @return feedback obtained after executing command
+     */
+    public String getFeedback() {
+        return feedbackToUser;
+    }
+
     public boolean isShowHelp() {
         return showHelp;
     }
 
     public boolean isExit() {
         return exit;
+    }
+
+    /** Checks whether user is requesting for a change in page.
+     * @return {@code true} only if user wants to calendar, diary, financial tracker, itinerary or address book to show
+     */
+    public boolean isShowPage() {
+        return showPage;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SampleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SampleCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Just a sample command.
+ */
+// todo: remove this class before v1.3
+public class SampleCommand extends Command {
+    public static final String COMMAND_WORD = "sample";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows you your calendar.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_SAMPLE_MESSAGE = "sample";
+    // todo-this-week: above showing_..._message should be the same as toString() value of the page which this command shows, see SamplePage
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_SAMPLE_MESSAGE, false, false, true);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,16 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.calendar.commands.CalendarCommand;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -75,6 +66,10 @@ public class AddressBookParser {
 
         case CalendarCommand.COMMAND_WORD:
             return new CalendarCommand();
+
+        // todo: remove this when everyone has implemented the UI of their page
+        case SampleCommand.COMMAND_WORD:
+            return new SampleCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -30,7 +30,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
-    private PageScenes pageScenes;
+    private Pages pages;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -67,9 +67,9 @@ public class MainWindow extends UiPart<Stage> {
         helpWindow = new HelpWindow();
 
         Scene primaryScene = primaryStage.getScene();
-        // todo-this-week: call the PageScene constructor with your page scene instead, e.g. PageScenes(primaryScene, diaryScene)
+        // todo-this-week: call the PageScene constructor with your page scene instead, e.g. Pages(primaryScene, diaryScene)
         // note that one of the PageScene's constructor is a vararg
-        pageScenes = new PageScenes(primaryScene);
+        pages = new Pages(primaryScene);
 
     }
 
@@ -173,7 +173,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handlePageChange(CommandResult commandResult) {
-        Scene requestedPage = pageScenes.getPage(commandResult);
+        Scene requestedPage = pages.getPage(commandResult);
         primaryStage.setScene(requestedPage);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -30,12 +30,12 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
+    private PageScenes pageScenes;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
-    private Scene primaryScene;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -65,6 +65,12 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        Scene primaryScene = primaryStage.getScene();
+        // todo-this-week: call the PageScene constructor with your page scene instead, e.g. PageScenes(primaryScene, diaryScene)
+        // note that one of the PageScene's constructor is a vararg
+        pageScenes = new PageScenes(primaryScene);
+
     }
 
     public Stage getPrimaryStage() {
@@ -162,6 +168,15 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    /**
+     * Changes application page.
+     */
+    @FXML
+    private void handlePageChange(CommandResult commandResult) {
+        Scene requestedPage = pageScenes.getPage(commandResult);
+        primaryStage.setScene(requestedPage);
+    }
+
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
     }
@@ -183,6 +198,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            if (commandResult.isShowPage()) {
+                handlePageChange(commandResult);
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/PageScenes.java
+++ b/src/main/java/seedu/address/ui/PageScenes.java
@@ -1,0 +1,35 @@
+package seedu.address.ui;
+
+import javafx.scene.Scene;
+import seedu.address.logic.commands.CommandResult;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PageScenes {
+    private List<Scene> pageScenes;
+    private Scene mainPageScene;
+
+    // todo: change this parameter to the specified scenes to minimise possible errors
+    // keep PageScene constructor package private to prevent creation of this class elsewhere
+    PageScenes(Scene mainPageScene, Scene... scenes) {
+        this.mainPageScene = mainPageScene;
+        pageScenes = Stream.of(scenes)
+                .collect(Collectors.toList());
+    }
+
+    public Scene getPage(CommandResult commandResult) {
+        String requestedPage = commandResult.getFeedback();
+        Optional<Scene> requestedPageScene = pageScenes.stream().filter(p -> p.toString().equals(requestedPage)).
+                findFirst();
+        // todo: when all pages have been added, throw error if requestedPageScene isEmpty
+        return requestedPageScene.orElseGet(() -> SamplePage.getScene());
+    }
+
+    public Scene getMainPageScene() {
+        return mainPageScene;
+    }
+
+}

--- a/src/main/java/seedu/address/ui/Pages.java
+++ b/src/main/java/seedu/address/ui/Pages.java
@@ -8,13 +8,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PageScenes {
+public class Pages {
     private List<Scene> pageScenes;
     private Scene mainPageScene;
 
     // todo: change this parameter to the specified scenes to minimise possible errors
     // keep PageScene constructor package private to prevent creation of this class elsewhere
-    PageScenes(Scene mainPageScene, Scene... scenes) {
+    Pages(Scene mainPageScene, Scene... scenes) {
         this.mainPageScene = mainPageScene;
         pageScenes = Stream.of(scenes)
                 .collect(Collectors.toList());

--- a/src/main/java/seedu/address/ui/SamplePage.java
+++ b/src/main/java/seedu/address/ui/SamplePage.java
@@ -1,0 +1,18 @@
+package seedu.address.ui;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.VBox;
+
+// todo: remove this class when everyone has implemented their page
+public class SamplePage {
+    static Scene getScene() {
+        Scene newScene = new Scene(new VBox());
+        return newScene;
+    }
+
+    // todo-this-week: toString value should be overwritten to match SampleCommand's feedback
+    @Override
+    public String toString() {
+        return "sample";
+    }
+}


### PR DESCRIPTION
I have added a class that is meant to store all the scenes (our pages and the main page). This class is called `PageScenes` and it can be found in the UI package. The most important change though is done in `MainWindow`. 

(For clarity of how these changes can be used, I added `SampleCommand` and `SamplePage` classes)

To enable the user to change to your page from the main page, simply go to the constructor of `MainWindow`, look for the code `new Pages(primaryScene);`. Then, add your scene to this constructor, e.g. if you have a `Scene samplePage = new SamplePage()`, then change the code above to `new Pages(primaryScene, samplePage)`. 

Next, in the **UI class** which is responsible for showing the user your page, override the `toString` method such that it returns the SAME value as the `feedbackToUser` value of the **command class** that is called when the page change occurs. In the case of `samplePage`, which is shown when `SampleCommand` is created and called, the `feedbackToUser` is "sample". Hence, in the UI class that is responsible for showing the sample page, the `toString` method should return "sample".

Now, to check that it works, just try typing "sample" into the command box of the application.

As I am afraid that the above explanation isn't clear, I have also added comments in the code specifying what should be done. Ctrl+F for "todo-this-week". 